### PR TITLE
add very limited page builder component with state & start trying to render generic compoents alongside custom

### DIFF
--- a/src/components/PageBuilder/index.jsx
+++ b/src/components/PageBuilder/index.jsx
@@ -1,6 +1,34 @@
 import React, { useState, useEffect } from 'react';
 import * as library from "../../lib/component-lib"
 
+const renderJSXComponent = (component) => {
+  if (!component || !component.type) {
+    return null;
+  }
+
+  const Component = determineComponentType(component);
+
+  if (!Component) {
+    return null;
+  }
+
+  return Component
+}
+
+const determineComponentType = (component) => {
+  if (!component || !component.type) {
+    return null;
+  }
+
+  const customComponent = library[component.type]; 
+
+  if (!customComponent) {
+    return React.createElement(component.type, component.props);
+  }
+
+  return customComponent;
+};
+
 function PageBuilder({ templateData, updateComponentIndex }) {
   const [template, setTemplate] = useState(templateData || { components: [] });
 
@@ -16,7 +44,7 @@ function PageBuilder({ templateData, updateComponentIndex }) {
 
     return template.components.map((component, index) => {
       try {
-        const Component = library[component.type];
+        const Component = renderJSXComponent(component);
 
         if (!Component) {
           throw new Error(`Component ${component.type} not found`);

--- a/src/components/PageBuilder/index.jsx
+++ b/src/components/PageBuilder/index.jsx
@@ -1,69 +1,10 @@
-import React, { useState, useEffect } from 'react';
-import * as library from "../../lib/component-lib"
+import React from 'react'
 
-const renderJSXComponent = (component) => {
-  if (!component || !component.type) {
-    return null;
-  }
-
-  const Component = determineComponentType(component);
-
-  if (!Component) {
-    return null;
-  }
-
-  return Component
-}
-
-const determineComponentType = (component) => {
-  if (!component || !component.type) {
-    return null;
-  }
-
-  const customComponent = library[component.type]; 
-
-  if (!customComponent) {
-    return React.createElement(component.type, component.props);
-  }
-
-  return customComponent;
-};
-
-function PageBuilder({ templateData, updateComponentIndex }) {
-  const [template, setTemplate] = useState(templateData || { components: [] });
-
-  useEffect(() => {
-    updateComponentIndex(Object.keys(library).filter(key => key !== 'default')); // indexing all exported components in the library to AppContext state
-    setTemplate(templateData);
-  }, [templateData]);
-
-  const renderComponents = () => {
-    if (!template || !template.components.length) {
-      return <div>Loading template...</div>; // Display a placeholder
-    }
-
-    return template.components.map((component, index) => {
-      try {
-        const Component = renderJSXComponent(component);
-
-        if (!Component) {
-          throw new Error(`Component ${component.type} not found`);
-        }
-
-        return (<Component {...component.props} key={`${component.type}-${index}`} />);
-      } catch (error) {
-        console.error(error);
-        return null;
-      }
-    });
-  };
-
+function PageBuilder({ }) {
+    
   return (
-    <div>
-      {/* Render loaded components */}
-      {renderComponents()}
-    </div>
-  );
+    <div>index</div>
+  )
 }
 
-export default PageBuilder;
+export default PageBuilder

--- a/src/components/PageBuilder/index.jsx
+++ b/src/components/PageBuilder/index.jsx
@@ -1,10 +1,20 @@
 import React from 'react'
+import { ComponentsPicker, PreviewMenu } from './partials'
 
-function PageBuilder({ }) {
-    
+function PageBuilder({ template, updateTemplate, components, submitTemplate, resetTemplate }) {
+
   return (
-    <div>index</div>
+    <div>
+      <ComponentsPicker {...{ updateTemplate, components, submitTemplate, resetTemplate }} />
+      <PreviewMenu {...{ template }} />
+    </div>
   )
+}
+
+PageBuilder.defaultProps = {
+  template: [],
+  updateTemplate: (prevTemplates) => { console.log(prevTemplates) },
+  components: []
 }
 
 export default PageBuilder

--- a/src/components/PageBuilder/partials/index.jsx
+++ b/src/components/PageBuilder/partials/index.jsx
@@ -1,0 +1,11 @@
+export const ComponentsPicker = () => {
+    return (
+        <div>index</div>
+    )
+}
+
+export const PreviewMenu = () => {
+    return (
+        <div>index</div>
+    )
+}

--- a/src/components/PageBuilder/partials/index.jsx
+++ b/src/components/PageBuilder/partials/index.jsx
@@ -1,11 +1,31 @@
-export const ComponentsPicker = () => {
+import PageRender from "../../PageRender"
+
+import styles from '../styles.module.css';
+
+export const ComponentsPicker = ({ updateTemplate, components, submitTemplate, resetTemplate }) => {
     return (
-        <div>index</div>
+        <div className={styles.componentPicker}>
+            <h4>Components</h4>
+            <ul>
+                {components.map((c, i) => <li key={i}><ComponentButton component={c} updateTemplate={updateTemplate} /></li>)}
+            </ul>
+
+            <div className={styles.componentPickerControls}>
+                <button onClick={resetTemplate}>Reset Template</button>
+                <button onClick={submitTemplate}>Submit Site</button>
+            </div>
+        </div>
     )
 }
 
-export const PreviewMenu = () => {
+const ComponentButton = ({ component, updateTemplate }) => {
     return (
-        <div>index</div>
+        <button onClick={() => updateTemplate(component)}>{component.type}</button>
+    )
+}
+
+export const PreviewMenu = ({ template }) => {
+    return (
+        <PageRender {...{ templateData: { components: template }, updateComponentIndex: () => { } }} style={{ 'scale': '.5', 'marginTop:': '0' }} />
     )
 }

--- a/src/components/PageBuilder/styles.module.css
+++ b/src/components/PageBuilder/styles.module.css
@@ -1,0 +1,55 @@
+.componentPicker {
+    position: fixed;
+    z-index: 1000;
+    top: 26px;
+    right: 26px;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    margin: 0 auto;
+    max-width: 1200px;
+
+    opacity: .4;
+
+    background-color: black;
+    border-radius: 6px;
+    padding: 6px 12px;
+
+    transition: opacity .3s;
+}
+
+.componentPicker:hover {
+ opacity: 1;
+}
+
+.componentPickerControls {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.componentPicker h4 {
+    color: white;
+    margin: 0;
+}
+
+
+.componentPicker ul {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    padding: 0;
+}
+
+.componentPicker ul li {
+    list-style-type: none;
+    margin: 0 6px;
+    cursor: pointer;
+
+    color: white;
+}
+
+.componentPicker ul li:hover {
+    text-decoration: underline;
+}

--- a/src/components/PageRender/index.jsx
+++ b/src/components/PageRender/index.jsx
@@ -29,7 +29,7 @@ const determineComponentType = (component) => {
   return customComponent;
 };
 
-function PageRender({ templateData, updateComponentIndex }) {
+function PageRender({ templateData, updateComponentIndex, style }) {
   const [template, setTemplate] = useState(templateData || { components: [] });
 
   useEffect(() => {
@@ -61,7 +61,7 @@ function PageRender({ templateData, updateComponentIndex }) {
   };
 
   return (
-    <div>
+    <div style={style}>
       {/* Render loaded components */}
       {renderComponents()}
     </div>

--- a/src/components/PageRender/index.jsx
+++ b/src/components/PageRender/index.jsx
@@ -1,0 +1,71 @@
+import React, { useState, useEffect } from 'react';
+import * as library from "../../lib/component-lib"
+
+const renderJSXComponent = (component) => {
+  if (!component || !component.type) {
+    return null;
+  }
+
+  const Component = determineComponentType(component);
+
+  if (!Component) {
+    return null;
+  }
+
+  return Component
+}
+
+const determineComponentType = (component) => {
+  if (!component || !component.type) {
+    return null;
+  }
+
+  const customComponent = library[component.type];
+
+  if (!customComponent) {
+    return React.createElement(component.type, component.props);
+  }
+
+  return customComponent;
+};
+
+function PageRender({ templateData, updateComponentIndex }) {
+  const [template, setTemplate] = useState(templateData || { components: [] });
+
+  useEffect(() => {
+    const indexedComponents = Object.keys(library).filter(key => key !== 'default')
+    .map(key => {console.log('values',library[key].params); return { type: key, props: library[key].defaultProps || {} }});
+    updateComponentIndex(indexedComponents); // indexing all exported components in the library to AppContext state
+    setTemplate(templateData);
+  }, [templateData]);
+
+  const renderComponents = () => {
+    if (!template || !template.components.length) {
+      return <div>Loading template...</div>; // Display a placeholder
+    }
+
+    return template.components.map((component, index) => {
+      try {
+        const Component = renderJSXComponent(component);
+
+        if (!Component) {
+          throw new Error(`Component ${component.type} not found`);
+        }
+
+        return (<Component {...component.props} key={`${component.type}-${index}`} />);
+      } catch (error) {
+        console.error(error);
+        return null;
+      }
+    });
+  };
+
+  return (
+    <div>
+      {/* Render loaded components */}
+      {renderComponents()}
+    </div>
+  );
+}
+
+export default PageRender;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,1 +1,2 @@
 export { default as PageRender } from './PageRender';
+export { default as PageBuilder } from './PageBuilder';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,1 +1,1 @@
-export { default as PageBuilder } from './PageBuilder'
+export { default as PageRender } from './PageRender';

--- a/src/context/appContext.jsx
+++ b/src/context/appContext.jsx
@@ -4,8 +4,12 @@ import React, { createContext, useContext, useState } from 'react';
 const AppContext = createContext(null);
 
 const defaultAppState = {
-    components: { index: null }
+    components: {
+        index:
+            [{ type: 'ContactForm', props: {} }, { type: 'HeadingWith4IconsAndArrows', props: { title: 'string', icon: [] } }, { type: 'HeadingWith6Icons', props: { title: 'string', icon: [] } }]
+    }
 }
+
 
 export const AppContextProvider = ({ children }) => {
     defaultAppState.components.index = JSON.parse(localStorage.getItem('componentsList')) || null;

--- a/src/pages/AllSites/index.jsx
+++ b/src/pages/AllSites/index.jsx
@@ -1,58 +1,66 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import lodash from 'lodash'
 import { useAppContext } from '../../context/appContext'
 
-const components = [{ type: 'ContactForm', props: {} }, { type: 'HeadingWith4IconsAndArrows', props: { title: 'string', icon: [] } }, { type: 'HeadingWith6Icons', props: { title: 'string', icon: [] } }] // temporary data, will be from a context or api
-
 function AllSites() {
+    const [pageState, setPageState] = useState({ components: [], template: [] })
     const { appState } = useAppContext()
-    
+
     const encodeData = (data) => {
         return btoa(JSON.stringify(data))
     }
 
-    const buildFakePage = (components, userValues) => {
+    const onComponentClick = (component) => {
+        if (!component) return
+        setPageState(prev => ({ ...prev, template: [...pageState.template, component] }))
+    }
 
+
+    const buildPage = (components, userValues) => {
         let processComponent = components.map((c, i) => {
             const componentData = lodash.cloneDeep(c)
             componentData.props = lodash.merge(componentData.props, userValues)
 
-            
             return componentData
         })
-        
-        console.log(processComponent)
 
         return { components: processComponent };
     }
 
+    useEffect(() => {
+        console.log(pageState.template)
+    }, [pageState])
+
+    useEffect(() => {
+        if (!appState.components.index) return
+
+        setPageState(prev => ({ ...prev, components: appState.components.index }));
+    }, [appState])
+
     return (
         <div>
-            <h3>All Sites</h3>
-            {appState.components.index && <p>Available components: {appState.components.index.join(', ')}</p>}
-            <p>(temporary data encoder)</p>
-            <ul>
-                {components?.map((component, index) => (
-                    <li key={index}>
-                        <a href={`/sites/render?data=${encodeData(buildFakePage([component], {
-                            title: 'test title', icon: [{
-                                icon: null,
-                                title: "Title goes here",
-                                desc: "Lorem ipsum dolor sit amet consectetur adipisicing elit. Dicta neque, officia rerum cum voluptatum asperiores quos! Dolor, ipsa ea eos laborum laboriosam doloribus voluptate quisquam sequi molestiae temporibus officia eveniet?",
-                            }]
-                        }))}`}>{component.type}</a>
-                    </li>
-                ))}
-                <a href={`/sites/render?data=${encodeData(buildFakePage([components[0], components[1], components[2]], {
-                            title: 'test title', icon: [{
-                                icon: null,
-                                title: "Title goes here",
-                                desc: "Lorem ipsum dolor sit amet consectetur adipisicing elit. Dicta neque, officia rerum cum voluptatum asperiores quos! Dolor, ipsa ea eos laborum laboriosam doloribus voluptate quisquam sequi molestiae temporibus officia eveniet?",
-                            }]
-                        }))}`}>bomba</a>
-            </ul>
+            <h3>Link-based Site builder</h3>
+            <p>You're to build a site from state using this menu, there will be a list of components and a submit button in which you can use to then generate and navigate to the site you've built</p>
+
+            <div>
+                <h4>Components</h4>
+                <ul>
+                    {pageState.components.map((c, i) => {
+                        return <li key={i} onClick={() => onComponentClick(c)}>{c.type}</li>
+                    })}
+                </ul>
+
+                <button onClick={() => {
+                    const fakePage = buildPage(pageState.template, {})
+                    const encodedData = encodeData(fakePage)
+                    window.location.href = `/sites/render?data=${encodedData}`
+                }
+                }>Build Site</button>
+
+            </div>
         </div>
     )
 }
+
 
 export default AllSites

--- a/src/pages/RenderSite/index.jsx
+++ b/src/pages/RenderSite/index.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { PageBuilder } from '../../components'
+import { PageRender } from '../../components'
 import { useParams } from 'react-router-dom'
 import axios from 'axios'
 import { useAppContext } from '../../context/appContext'
@@ -30,7 +30,7 @@ function RenderSite({ }) {
             <h1>Dynamic Components</h1>
             {templateData.loading && <div>Loading...</div>}
             {templateData.error && <div>Error: {templateData.error.message}</div>}
-            {templateData.data && <PageBuilder templateData={templateData.data} updateComponentIndex={updateComponentIndex} />}
+            {templateData.data && <PageRender templateData={templateData.data} updateComponentIndex={updateComponentIndex} />}
         </>
     )
 }

--- a/src/pages/RenderSiteClientSide/index.jsx
+++ b/src/pages/RenderSiteClientSide/index.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { PageBuilder } from '../../components';
+import { PageRender } from '../../components';
 import { useSearchParams } from 'react-router-dom';
 import { useAppContext } from '../../context/appContext';
 
@@ -29,7 +29,7 @@ function RenderSiteClientSide() {
             <h1>Dynamic Components</h1>
             {templateData.loading && <div>Loading...</div>}
             {templateData.error && <div>Error: {templateData.error.message}</div>}
-            {templateData.data && <PageBuilder templateData={templateData.data} updateComponentIndex={updateComponentIndex} />}
+            {templateData.data && <PageRender templateData={templateData.data} updateComponentIndex={updateComponentIndex} />}
         </>
     );
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,4 @@
+
+export const encodeToBase64 = (data) => {
+    return btoa(JSON.stringify(data))
+}


### PR DESCRIPTION
+ add very limited page builder component with state 
```js
import React from 'react'
import { ComponentsPicker, PreviewMenu } from './partials'

function PageBuilder({ template, updateTemplate, components, submitTemplate, resetTemplate }) {

  return (
    <div>
      <ComponentsPicker {...{ updateTemplate, components, submitTemplate, resetTemplate }} />
      <PreviewMenu {...{ template }} />
    </div>
  )
}

PageBuilder.defaultProps = {
  template: [],
  updateTemplate: (prevTemplates) => { console.log(prevTemplates) },
  components: []
}

export default PageBuilder
```

+ start trying to render generic components alongside custom

```js
 const indexedComponents = Object.keys(library).filter(key => key !== 'default')
    .map(key => {console.log('values',library[key].params); return { type: key, props: library[key].defaultProps || {} }});
```




































































































































































































































































































































































































































































































